### PR TITLE
For Python3.x

### DIFF
--- a/tfgraphviz/__init__.py
+++ b/tfgraphviz/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from graphviz_wrapper import board
+from .graphviz_wrapper import board
 
 __author__  = 'akimacho'
 __version__ = '0.0.1'

--- a/tfgraphviz/graphviz_wrapper.py
+++ b/tfgraphviz/graphviz_wrapper.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import re
 import uuid
-import tensorflow as tf
 import graphviz as gv
 
 


### PR DESCRIPTION
Fixed to work on Python 3.x:

+ Change IMPLICIT relative imports (`from graphviz_wrapper import board`) to EXPLICIT relative imports (`from .graphviz_wrapper import board`).
+ (In addition, ) remove unnecessary imports.

Checked to work both Python 2.7.x/3.5.x with TensorFlow 1.0.