### PR TITLE
Fixing ascii/unicode problem with Python2

### DIFF
--- a/tfgraphviz/graphviz_wrapper.py
+++ b/tfgraphviz/graphviz_wrapper.py
@@ -153,7 +153,7 @@ def edge_label(shape):
     else: label = "%i" % shape[0]
     for s in shape[1:]:
         if s is None: label += "×?"
-        else: label += "×%i" % s
+        else: label += u"×%i" % s
     return label
 
 


### PR DESCRIPTION
The character × in the edge label requires unicode. Thus, the string literal needs a "u" in front to be compatible with Python 2.