### PR TITLE
Extending functionality

### DIFF
--- a/tfgraphviz/__init__.py
+++ b/tfgraphviz/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .graphviz_wrapper import board
+from .graphviz_wrapper import board, add_digraph, add_digraph_node, add_digraph_edge
 
 
 __author__  = "akimach"


### PR DESCRIPTION
- Added proper tooltips
- Fixed logic to render function names to check op type, not op name
- Added ability to override functions to create digraph, node and edge like:

```Python
def custom_add_digraph_node(digraph, name, op, attributes=None):
    attributes=[]
    if op is not None and 'PartitionedCall' in op.type:
        attributes.append(('fillcolor', 'blue'))
    tfg.add_digraph_node(digraph, name, op, attributes)

tfg.board(tf_g, depth=10, name_regex=".*", add_digraph_node_func=custom_add_digraph_node)
```